### PR TITLE
Fix config mistake for L-add to L-added

### DIFF
--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -48,11 +48,14 @@ Default:
 
 ### Sample Config.toml
 ```toml
-repo_path = "/home/simeonzahariev/work/Manta"
+# Optional as there are CLI arguments too, defaults to same directory
+# repo_path = "/home/simeonzahariev/work/Manta"
+
+# Mandatory 
 version_pattern = "v[0-9]+.[0-9]+.[0-9]+"
 
 [labels]
-L-add = "Added"
+L-added = "Added"
 L-changed = "Changed"
 L-deprecated = "Deprecated"
 L-removed = "Removed"

--- a/changelog-generator/README.md
+++ b/changelog-generator/README.md
@@ -48,7 +48,7 @@ Default:
 
 ### Sample Config.toml
 ```toml
-# Optional as there are CLI arguments too, defaults to same directory
+# Optional as there are CLI arguments too, defaults to the current working directory
 # repo_path = "/home/simeonzahariev/work/Manta"
 
 # Mandatory 

--- a/changelog-generator/config.toml
+++ b/changelog-generator/config.toml
@@ -1,4 +1,4 @@
-# Optional as there are CLI arguments too, defaults to same directory
+# Optional as there are CLI arguments too, defaults to the current working directory
 # repo_path = "/home/simeonzahariev/work/Manta"
 
 # Mandatory 

--- a/changelog-generator/config.toml
+++ b/changelog-generator/config.toml
@@ -1,4 +1,3 @@
-
 repo_path = "/home/simeonzahariev/work/Manta"
 version_pattern = "v[0-9]+.[0-9]+.[0-9]+"
 
@@ -16,3 +15,4 @@ A-calamari = "CA"
 A-dolphin = "DO"
 
 [prefix_labels]
+

--- a/changelog-generator/config.toml
+++ b/changelog-generator/config.toml
@@ -3,7 +3,7 @@ repo_path = "/home/simeonzahariev/work/Manta"
 version_pattern = "v[0-9]+.[0-9]+.[0-9]+"
 
 [labels]
-L-add = "Added"
+L-added = "Added"
 L-changed = "Changed"
 L-deprecated = "Deprecated"
 L-removed = "Removed"

--- a/changelog-generator/config.toml
+++ b/changelog-generator/config.toml
@@ -1,4 +1,7 @@
-repo_path = "/home/simeonzahariev/work/Manta"
+# Optional as there are CLI arguments too, defaults to same directory
+# repo_path = "/home/simeonzahariev/work/Manta"
+
+# Mandatory 
 version_pattern = "v[0-9]+.[0-9]+.[0-9]+"
 
 [labels]


### PR DESCRIPTION
Signed-off-by: Apokalip <simeon@manta.network>

Fixing mistake in config, as L-added was written as L-add in the sample config but Manta repo uses L-added