### PR TITLE
Apokalip/repo path indexing

### DIFF
--- a/changelog-generator/config.toml
+++ b/changelog-generator/config.toml
@@ -18,4 +18,3 @@ A-calamari = "CA"
 A-dolphin = "DO"
 
 [prefix_labels]
-

--- a/changelog-generator/config.toml
+++ b/changelog-generator/config.toml
@@ -18,3 +18,4 @@ A-calamari = "CA"
 A-dolphin = "DO"
 
 [prefix_labels]
+

--- a/changelog-generator/src/config.rs
+++ b/changelog-generator/src/config.rs
@@ -123,7 +123,7 @@ impl<'a> Config<'a> {
         if !cli_repo_path.is_empty() {
             repo_path = Some(cli_repo_path.to_string());
         } else {
-            if let Some(p) = config_data["repo_path"].as_str() {
+            if let Some(p) = config_data.get("repo_path") {
                 repo_path = Some(p.to_string());
             }
         }


### PR DESCRIPTION
Fixing repo_path toml indexing as [] syntax will fail instead of returning None like get(index)
