### PR TITLE
Check if master contains PR-less commit and correct exit codes

### DIFF
--- a/changelog-generator/src/config.rs
+++ b/changelog-generator/src/config.rs
@@ -94,7 +94,6 @@ impl<'a> Config<'a> {
                 }
             }
         }
-
         Self::create_from_path(cli_repo_path, auth_pair, config_path)
     }
 
@@ -124,7 +123,11 @@ impl<'a> Config<'a> {
             repo_path = Some(cli_repo_path.to_string());
         } else {
             if let Some(p) = config_data.get("repo_path") {
-                repo_path = Some(p.to_string());
+                repo_path = Some(
+                    p.as_str()
+                        .expect("could not read repo_path from config file")
+                        .to_string(),
+                );
             }
         }
 

--- a/changelog-generator/src/parse.rs
+++ b/changelog-generator/src/parse.rs
@@ -139,7 +139,6 @@ pub fn make_changelog_path(config: &Config) -> String {
 // branch is contained in the master branch
 // 'to_commit' collect from start to to_commit range, (to_commit, "") as git log is reverse order
 pub fn collect_master_commit_ids(config: &Config, to_commit: &str) -> Vec<String> {
-
     //get branch name to reverse checkout changes
     let r_branch = get_branch_name(config);
     // master checkout
@@ -173,7 +172,6 @@ pub fn collect_master_commit_ids(config: &Config, to_commit: &str) -> Vec<String
     master_commits.reverse();
     let mut master_commit_ids: Vec<String> = vec![];
     for master_commit_str in master_commits.iter() {
-
         master_commit_ids.push(
             master_commit_str
                 .split_whitespace()
@@ -192,7 +190,7 @@ pub fn collect_master_commit_ids(config: &Config, to_commit: &str) -> Vec<String
     git_checkout_back
         .output()
         .expect("Failed manta master branch checkout back command");
-    
+
     master_commit_ids
 }
 
@@ -202,7 +200,7 @@ pub fn collect_master_commit_ids(config: &Config, to_commit: &str) -> Vec<String
 // calls to the API without getting timed out or limited in the number of calls per hour
 pub fn parse_commits(input: Vec<String>, login_info: (&str, &str), config: &Config) -> Vec<Commit> {
     let mut commits: Vec<Commit> = vec![];
-    
+
     // get master commit relative to this release commits
     let end_commit_id = input[0]
         .split_whitespace()

--- a/changelog-generator/src/parse.rs
+++ b/changelog-generator/src/parse.rs
@@ -131,8 +131,6 @@ pub fn make_changelog_path(config: &Config) -> String {
     changelog_path
 }
 
-// checksout master, collects commits ids then checks back to the original branch
-// changing nothing
 // Used to collect commit IDs to compare if a commit in the release
 // branch is contained in the master branch
 // 'to_commit' collect from start to to_commit range, (to_commit, "") as git log is reverse order
@@ -143,8 +141,8 @@ pub fn collect_master_commit_ids(config: &Config, to_commit: &str) -> Vec<String
         git_fetch.arg("-C").arg(r_path);
     };
     git_fetch.arg("fetch");
-    git_fetch.arg("origin/manta");
-    git_fetch.output().expect("Failed git fetch origin/manta call");
+    git_fetch.arg("origin");
+    git_fetch.output().expect("Failed git fetch origin call");
 
     let mut git_log = process::Command::new("git");
     if let Some(r_path) = &config.repo_path {

--- a/changelog-generator/src/parse.rs
+++ b/changelog-generator/src/parse.rs
@@ -428,7 +428,7 @@ pub fn run() {
         &config,
     );
 
-    let mut new_changelog_block = format!("# CHANGELOG \n\n## {}\n", current_version);
+    let mut new_changelog_block = format!("# CHANGELOG\n\n## {}\n", current_version);
 
     for (label, prs) in changelog_data {
         //write label name

--- a/changelog-generator/src/parse.rs
+++ b/changelog-generator/src/parse.rs
@@ -354,10 +354,10 @@ pub fn prepare_changelog_strings(
         for label in commit.labels.iter() {
             if let Some(label_str) = config.labels.get(label) {
                 if !suffix.is_empty() {
-                    suffix = format!("[{}]", suffix);
+                    suffix = format!(" [{}]", suffix);
                 }
                 let commit_str = format!(
-                    r"-[\#{}]({}) {} {}",
+                    r"-[\#{}]({}) {}{}",
                     commit.pr_id,
                     commit.relative_pr_url,
                     commit.commit_msg.trim(),
@@ -454,6 +454,7 @@ pub fn run() {
         }
         new_changelog_block.push_str("\n");
     }
+    println!("{}",new_changelog_block);
     //remove last trailing new line
     //new_changelog_block = new_changelog_block[..new_changelog_block.len()].to_string();
     // add in previous changelog data
@@ -462,6 +463,7 @@ pub fn run() {
     // go back to start of file and overwrite
     // using overwriting over whole contents as that will let us
     // rewrite previous releases too if they get yanked(aka re-release)
+    
     changelog_handle.seek(SeekFrom::Start(0)).unwrap();
     changelog_handle
         .write_all(new_changelog_block.as_bytes())


### PR DESCRIPTION
Adding Checks for generator to check if PR-less commit is in master(should not be) and correct exit codes; Fix on string parsing from config file fixed too

Signed-off-by: Apokalip <simeon@manta.network>