### PR TITLE
Adding space after dash to fix github changelog preview

### DIFF
--- a/changelog-generator/src/parse.rs
+++ b/changelog-generator/src/parse.rs
@@ -342,7 +342,7 @@ pub fn prepare_changelog_strings(
                     suffix = format!(" [{}]", suffix);
                 }
                 let commit_str = format!(
-                    r"-[\#{}]({}) {}{}",
+                    r"- [\#{}]({}) {}{}",
                     commit.pr_id,
                     commit.relative_pr_url,
                     commit.commit_msg.trim(),


### PR DESCRIPTION
Signed-off-by: Apokalip <simeon@manta.network>